### PR TITLE
Fix for typo in generatePrivate resulting in invalid key

### DIFF
--- a/curve25519.cabal
+++ b/curve25519.cabal
@@ -17,7 +17,7 @@ library
   exposed-modules:     Crypto.Curve25519,
                        Crypto.Curve25519.Exceptions,
                        Crypto.Curve25519.Pure
-  build-depends:       base       >= 4.7  && < 4.9,
+  build-depends:       base       >= 4.6  && < 4.9,
                        bytestring >= 0.10 && < 0.12,
                        crypto-api >= 0.10 && < 0.14
   hs-source-dirs:      src
@@ -32,7 +32,7 @@ test-suite test-curve25519
   main-is:             Test.hs
   cc-options:          -Dmain=ctest_main
   c-sources:           upstream-c/test-curve25519.c
-  build-depends:       base                       >= 4.7     && < 4.9,
+  build-depends:       base                       >= 4.6     && < 4.9,
                        bytestring                 >= 0.10    && < 0.12,
                        crypto-api                 >= 0.10    && < 0.14,
                        curve25519                 >= 0.2     && < 0.3,

--- a/curve25519.cabal
+++ b/curve25519.cabal
@@ -1,5 +1,5 @@
 name:                curve25519
-version:             0.2.1
+version:             0.2.2
 synopsis:            Fast implementations of the curve25519 elliptic curve primitives.
 description:         Haskell bindings and extensions to the curve25519-donna
                      codebase.

--- a/src/Crypto/Curve25519/Pure.hs
+++ b/src/Crypto/Curve25519/Pure.hs
@@ -7,6 +7,7 @@ module Crypto.Curve25519.Pure(
          PrivateKey
        , PublicKey
        , importPublic, exportPublic
+       , importPrivate, exportPrivate
        , generatePrivate
        , generatePublic
        , generateKeyPair
@@ -24,6 +25,8 @@ import Foreign.C.Types
 import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import System.IO.Unsafe
+import Data.Maybe (fromJust)
+import Data.List (foldl')
 
 -- |The type of a Curve25519 private key.
 newtype PrivateKey = Priv ByteString
@@ -42,26 +45,41 @@ generatePrivate :: CryptoRandomGen g => g -> Either GenError (PrivateKey, g)
 generatePrivate g =
   case genBytes 32 g of
     Left e              -> Left e
-    Right (bytesbs, g') ->
-      let Just (b0, b1_31)  = BS.uncons bytesbs
-          Just (b1_30, b31) = BS.unsnoc b1_31
-          b0'               = b0  .&. 248
-          b31'              = b31 .&. 127
-          b31''             = b31 .|. 64
-          bytes             = (b0' `BS.cons` b1_30) `BS.snoc` b31''
-      in Right (Priv bytes, g')
+    Right (bytesbs, g') -> Right (fromJust (importPrivate bytesbs), g')
+
+-- | Imports a 'ByteString' to use as private key.
+-- The 'ByteString' must be exactly 32 bytes long for this to work.
+--
+-- Though minor changes may be made to create a valid key this property is guaranteed:
+-- prop> (\x -> importPrivate x >>= (importPrivate . exportPrivate)) = importPrivate
+importPrivate :: ByteString -> Maybe PrivateKey
+importPrivate bstr
+  | BS.length bstr /= 32 = Nothing
+  | otherwise  = 
+    let Just (b0, b1_31)  = BS.uncons bstr
+        Just (b1_30, b31) = BS.unsnoc b1_31
+        b0'               = b0   .&. 248
+        b31'              = b31  .&. 127
+        b31''             = b31' .|. 64
+        bytes             = (b0' `BS.cons` b1_30) `BS.snoc` b31''
+    in Just $ Priv bytes
+
+-- | Export a private key to a 'ByteString'
+exportPrivate :: PrivateKey -> ByteString
+exportPrivate (Priv bstr) = bstr
+
 
 -- |Randomly generate a Curve25519 public key.
 generatePublic :: PrivateKey -> PublicKey
 generatePublic (Priv priv) = Pub (curve25519 priv basePoint)
 
--- |Import a public key from a ByteString. The ByteString must be exactly
--- 32 bytes long for this to work.
+-- |Import a public key from a 'ByteString'.
+-- The 'ByteString' must be exactly 32 bytes long for this to work.
 importPublic :: ByteString -> Maybe PublicKey
 importPublic bstr | BS.length bstr == 32 = Just (Pub bstr)
                   | otherwise            = Nothing
 
--- |Export a public key to a ByteString.
+-- |Export a public key to a 'ByteString'.
 exportPublic :: PublicKey -> ByteString
 exportPublic (Pub bstr) = bstr
 
@@ -92,10 +110,9 @@ basePoint :: ByteString
 basePoint = BS.cons 9 (BS.replicate 31 0)
 
 buildNumber :: ByteString -> Integer
-buildNumber bstr = run 0 (BS.unpack bstr)
+buildNumber bstr = foldl' run 0 (BS.unpack bstr)
  where
-  run acc []     = acc
-  run acc (x:xs) = run ((acc * 256) + fromIntegral x) xs
+  run acc x = (acc `shiftL` 8) + fromIntegral x
 
 foreign import ccall unsafe
   curve25519_donna :: Ptr Word8 -> Ptr CChar -> Ptr CChar -> IO ()


### PR DESCRIPTION
A typo existed in `generatePrivate` where `b31''` depended on `b31` instead of `b31'`. This caused invalid keys. (Though donna would correct this when used since it applies the same bitwise operations.)

I also added `importPrivate` and `exportPrivate` to allow users of the library to use those and not resort to `unsafeCoerce`. I also took the liberty to bump up the version number and allow base 4.6 which is still in the default haskell-platform on some systems.
